### PR TITLE
Updated Google packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ tutorial](https://docs.particle.io/tutorials/topics/google-cloud-platform/#stori
 
 #### Clone the repository
 
-`git clone https://github.com/spark/google-cloud-datastore-tutorial.git`
+`git clone https://github.com/particle-iot/google-cloud-datastore-tutorial.git`
 
 #### Add your Private Key
 
@@ -64,7 +64,7 @@ Open up `tutorial.js` and update the `config` object for your Google
 Cloud Platform configuration:
 
 ```
-var config = {
+let config = {
 	gcpProjectId: '[YOUR PROJECT ID]',
 	gcpPubSubSubscriptionName: '[YOUR PUB/SUB SUBSCRIPTION NAME]',
 	gcpServiceAccountKeyFilePath: './gcp_private_key.json'

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
   "license": "ISC",
   "dependencies": {
     "colors": "^1.1.2",
-    "google-cloud": "^0.40.0",
+    "@google-cloud/datastore": "^1.4.2",
+    "@google-cloud/pubsub": "^0.20.0",
     "util": "^0.10.3"
   }
 }

--- a/tutorial.js
+++ b/tutorial.js
@@ -1,79 +1,89 @@
-var colors = require('colors');
-var util = require('util');
+let colors = require('colors')
+let util = require('util')
+let PubSub = require('@google-cloud/pubsub')
+let Datastore = require('@google-cloud/datastore')
 
 /* CONFIGURATION */
-var config = {
-	gcpProjectId: '',
-	gcpPubSubSubscriptionName: '',
-	gcpServiceAccountKeyFilePath: './gcp_private_key.json'
+let config = {
+    gcpProjectId: '',
+    gcpPubSubSubscriptionName: '',
+    gcpServiceAccountKeyFilePath: './gcp_private_key.json'
 }
 _checkConfig();
 /* END CONFIGURATION */
-console.log(colors.magenta('Authenticating with Google Cloud...'))
-var gcloud = require('google-cloud')({
+
+/* PUBSUB */
+console.log(colors.magenta('Authenticating PubSub with Google Cloud...'))
+const pubsub = new PubSub({
     projectId: config.gcpProjectId,
-	keyFilename: config.gcpServiceAccountKeyFilePath,
-});
+    keyFilename: config.gcpServiceAccountKeyFilePath,
+})
 console.log(colors.magenta('Authentication successful!'))
 
+const subscription = pubsub.subscription(config.gcpPubSubSubscriptionName);
+subscription.on('message', message => {
+    console.log(colors.cyan('Particle event received from Pub/Sub!\r\n'), _createParticleEventObjectForStorage(message, true));
+    // Called every time a message is received.
+    // message.id = ID used to acknowledge its receival.
+    // message.data = Contents of the message.
+    // message.attributes = Attributes of the message.
+    storeEvent(message);
+    message.ack();
+});
+/* END PUBSUB */
 
-var datastore = gcloud.datastore();
-var pubsub = gcloud.pubsub();
-
-
-var subscription = pubsub.subscription(config.gcpPubSubSubscriptionName);
-
+/* DATASTORE */
+console.log(colors.magenta('Authenticating Datastore with Google Cloud...'))
+const datastore = new Datastore({
+    projectId: config.gcpProjectId,
+    keyFilename: config.gcpServiceAccountKeyFilePath,
+})
+console.log(colors.magenta('Authentication successful!'))
 
 function storeEvent(message) {
-    var key = datastore.key('ParticleEvent');
+    let key = datastore.key('ParticleEvent');
 
-    datastore.save({
-        key: key,
-        data: _createEventObjectForStorage(message)
-    }, function(err) {
-		if(err) {
-			console.log(colors.red('There was an error storing the event'), err);
-		}
-		console.log(colors.green('Particle event stored in Datastore!\r\n'), _createEventObjectForStorage(message, true))
-    });
+    datastore
+        .save({
+            key: key,
+            data: _createParticleEventObjectForStorage(message)
+        })
+        .then(() => {
+            console.log(colors.green('Particle event stored in Datastore!\r\n'), _createParticleEventObjectForStorage(message, true))
+        })
+        .catch(err => {
+            console.log(colors.red('There was an error storing the event:'), err);
+        });
 
 };
+/* END DATASTORE */
 
-subscription.on('message', function(message) {
-	console.log(colors.cyan('Particle event received from Pub/Sub!\r\n'), _createEventObjectForStorage(message, true));
-	// Called every time a message is received.
-	// message.id = ID used to acknowledge its receival.
-	// message.data = Contents of the message.
-	// message.attributes = Attributes of the message.
-	storeEvent(message);
-	message.ack();
-});
-
+/* HELPERS */
 function _checkConfig() {
-	if(config.gcpProjectId === ''  || !config.gcpProjectId) {
-		console.log(colors.red('You must set your Google Cloud Platform project ID in tutorial.js'));
-		process.exit(1);
-	}
-	if(config.gcpPubSubSubscriptionName === '' || !config.gcpPubSubSubscriptionName) {
-		console.log(colors.red('You must set your Google Cloud Pub/Sub subscription name in tutorial.js'));
-		process.exit(1);
-	}
+    if (config.gcpProjectId === '' || !config.gcpProjectId) {
+        console.log(colors.red('You must set your Google Cloud Platform project ID in pubSubToDatastore.js'));
+        process.exit(1);
+    }
+    if (config.gcpPubSubSubscriptionName === '' || !config.gcpPubSubSubscriptionName) {
+        console.log(colors.red('You must set your Google Cloud Pub/Sub subscription name in pubSubToDatastore.js'));
+        process.exit(1);
+    }
 };
 
-function _createEventObjectForStorage(message, log) {
-	var obj = {
-		gc_pub_sub_id: message.id,
-		device_id: message.attributes.device_id,
-		event: message.attributes.event,
-		data: message.data,
-		published_at: message.attributes.published_at
-	}
+function _createParticleEventObjectForStorage(message, log) {
 
-	if(log) {
-		return colors.grey(util.inspect(obj));
-	} else {
-		return obj;
-	}
+    let obj = {
+        gc_pub_sub_id: message.id,
+        device_id: message.attributes.device_id,
+        event: message.attributes.event,
+        data: data,
+        published_at: message.attributes.published_at
+    }
+
+    if (log) {
+        return colors.grey(util.inspect(obj));
+    } else {
+        return obj;
+    }
 };
-
-
+/* END HELPERS */


### PR DESCRIPTION
The package used currently for interacting with Google services has been deprecated in favour of splitting the packages into their respective services.

The older package also has issues on more recent versions of Node (>v6); which has been reported in #8. The updated packages resolve this issue.

I've also updated `tutorial.js` to use ES6 syntax.

I had to go through the update process to use this in our own project that utilises Particle devices, and figured that I would submit a pull to this in the spirit of #Hacktoberfest.