### PR TITLE
Update tutorial.js

### DIFF
--- a/tutorial.js
+++ b/tutorial.js
@@ -76,7 +76,7 @@ function _createParticleEventObjectForStorage(message, log) {
         gc_pub_sub_id: message.id,
         device_id: message.attributes.device_id,
         event: message.attributes.event,
-        data: data,
+        data: message.data,
         published_at: message.attributes.published_at
     }
 


### PR DESCRIPTION
Fix mapping to obj from message where `data` was undefined.
`_createParticleEventObjectForStorage` should create `obj.data` from `message.data`, not from an undefined `data` var.